### PR TITLE
Intro showcase state

### DIFF
--- a/app/src/main/java/com/canopas/campose/showcase/MainActivity.kt
+++ b/app/src/main/java/com/canopas/campose/showcase/MainActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,7 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -49,8 +47,9 @@ import androidx.compose.ui.unit.sp
 import com.canopas.campose.showcase.ui.theme.JetTapTargetTheme
 import com.canopas.campose.showcase.ui.theme.ThemeColor
 import com.canopas.lib.showcase.IntroShowCase
-import com.canopas.lib.showcase.IntroShowcaseTargets
 import com.canopas.lib.showcase.ShowcaseStyle
+import com.canopas.lib.showcase.introShowCaseTarget
+import com.canopas.lib.showcase.rememberIntroShowCaseState
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,9 +70,8 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun ShowcaseSample() {
-    val targets = remember {
-        mutableStateMapOf<String, IntroShowcaseTargets>()
-    }
+    val introShowCaseState = rememberIntroShowCaseState()
+
     var showAppIntro by remember {
         mutableStateOf(true)
     }
@@ -88,78 +86,76 @@ fun ShowcaseSample() {
                     elevation = 0.dp,
                     navigationIcon = {
                         IconButton(onClick = {},
-                            modifier = Modifier.onGloballyPositioned { coordinates ->
-                                targets["back"] = IntroShowcaseTargets(
-                                    4, coordinates,
-                                    style = ShowcaseStyle.Default.copy(
-                                        backgroundColor = Color(0xFF7C99AC), // specify color of background
-                                        backgroundAlpha = 0.98f, // specify transparency of background
-                                        targetCircleColor = Color.White // specify color of target circle
-                                    ),
-                                    content = {
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Image(
-                                                painterResource(id = R.drawable.go_back),
-                                                contentDescription = null,
-                                                modifier = Modifier
-                                                    .size(100.dp)
-                                                    .padding(top = 10.dp)
+                            modifier = Modifier.introShowCaseTarget(
+                                state = introShowCaseState,
+                                index = 4,
+                                style = ShowcaseStyle.Default.copy(
+                                    backgroundColor = Color(0xFF7C99AC), // specify color of background
+                                    backgroundAlpha = 0.98f, // specify transparency of background
+                                    targetCircleColor = Color.White // specify color of target circle
+                                ),
+                                content = {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Image(
+                                            painterResource(id = R.drawable.go_back),
+                                            contentDescription = null,
+                                            modifier = Modifier
+                                                .size(100.dp)
+                                                .padding(top = 10.dp)
+                                        )
+                                        Column {
+                                            Text(
+                                                text = "Go back!!",
+                                                color = Color.White,
+                                                fontSize = 24.sp,
+                                                fontWeight = FontWeight.Bold
                                             )
-                                            Column {
-                                                Text(
-                                                    text = "Go back!!",
-                                                    color = Color.White,
-                                                    fontSize = 24.sp,
-                                                    fontWeight = FontWeight.Bold
-                                                )
-                                                Text(
-                                                    text = "You can go back by clicking here.",
-                                                    color = Color.White,
-                                                    fontSize = 16.sp
-                                                )
-                                            }
-
+                                            Text(
+                                                text = "You can go back by clicking here.",
+                                                color = Color.White,
+                                                fontSize = 16.sp
+                                            )
                                         }
                                     }
-                                )
-                            }) {
+                                },
+                            )
+                        ) {
                             Icon(Icons.Filled.ArrowBack, contentDescription = "Search")
                         }
                     },
                     actions = {
                         IconButton(
                             onClick = {},
-                            modifier = Modifier.onGloballyPositioned { coordinates ->
-                                targets["search"] = IntroShowcaseTargets(
-                                    2, coordinates,
-                                    style = ShowcaseStyle.Default.copy(
-                                        backgroundColor = Color(0xFF9AD0EC), // specify color of background
-                                        backgroundAlpha = 0.98f, // specify transparency of background
-                                        targetCircleColor = Color.White // specify color of target circle
-                                    ),
-                                    content = {
-                                        Column {
-                                            Image(
-                                                painterResource(id = R.drawable.search_example),
-                                                contentDescription = null,
-                                                modifier = Modifier.size(100.dp)
-                                            )
+                            modifier = Modifier.introShowCaseTarget(
+                                state = introShowCaseState,
+                                index = 2,
+                                style = ShowcaseStyle.Default.copy(
+                                    backgroundColor = Color(0xFF9AD0EC), // specify color of background
+                                    backgroundAlpha = 0.98f, // specify transparency of background
+                                    targetCircleColor = Color.White // specify color of target circle
+                                ),
+                                content = {
+                                    Column {
+                                        Image(
+                                            painterResource(id = R.drawable.search_example),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(100.dp)
+                                        )
 
-                                            Text(
-                                                text = "Search anything!!",
-                                                color = Color.Black,
-                                                fontSize = 24.sp,
-                                                fontWeight = FontWeight.Bold
-                                            )
-                                            Text(
-                                                text = "You can search anything by clicking here.",
-                                                color = Color.Black,
-                                                fontSize = 16.sp
-                                            )
-                                        }
+                                        Text(
+                                            text = "Search anything!!",
+                                            color = Color.Black,
+                                            fontSize = 24.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                        Text(
+                                            text = "You can search anything by clicking here.",
+                                            color = Color.Black,
+                                            fontSize = 16.sp
+                                        )
                                     }
-                                )
-                            },
+                                }
+                            )
                         ) {
                             Icon(Icons.Filled.Search, contentDescription = "Search")
                         }
@@ -169,42 +165,40 @@ fun ShowcaseSample() {
             floatingActionButton = {
                 FloatingActionButton(
                     onClick = {},
-                    modifier = Modifier.onGloballyPositioned { coordinates ->
-                        targets["email"] = IntroShowcaseTargets(
-                            1, coordinates,
-                            style = ShowcaseStyle.Default.copy(
-                                backgroundColor = Color(0xFF1C0A00), // specify color of background
-                                backgroundAlpha = 0.98f, // specify transparency of background
-                                targetCircleColor = Color.White // specify color of target circle
-                            ),
-                            // specify the content to show to introduce app feature
-                            content = {
-                                Column {
-                                    Text(
-                                        text = "Check emails",
-                                        color = Color.White,
-                                        fontSize = 24.sp,
-                                        fontWeight = FontWeight.Bold
-                                    )
-                                    Text(
-                                        text = "Click here to check/send emails",
-                                        color = Color.White,
-                                        fontSize = 16.sp
-                                    )
-                                    Spacer(modifier = Modifier.height(10.dp))
-                                    Icon(
-                                        painterResource(id = R.drawable.right_arrow),
-                                        contentDescription = null,
-                                        modifier = Modifier
-                                            .size(80.dp)
-                                            .align(Alignment.End),
-                                        tint = Color.White
-                                    )
-                                }
-
+                    modifier = Modifier.introShowCaseTarget(
+                        state = introShowCaseState,
+                        index = 1,
+                        style = ShowcaseStyle.Default.copy(
+                            backgroundColor = Color(0xFF1C0A00), // specify color of background
+                            backgroundAlpha = 0.98f, // specify transparency of background
+                            targetCircleColor = Color.White // specify color of target circle
+                        ),
+                        // specify the content to show to introduce app feature
+                        content = {
+                            Column {
+                                Text(
+                                    text = "Check emails",
+                                    color = Color.White,
+                                    fontSize = 24.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                                Text(
+                                    text = "Click here to check/send emails",
+                                    color = Color.White,
+                                    fontSize = 16.sp
+                                )
+                                Spacer(modifier = Modifier.height(10.dp))
+                                Icon(
+                                    painterResource(id = R.drawable.right_arrow),
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(80.dp)
+                                        .align(Alignment.End),
+                                    tint = Color.White
+                                )
                             }
-                        )
-                    },
+                        }
+                    ),
                     backgroundColor = ThemeColor,
                     contentColor = Color.White,
                     elevation = FloatingActionButtonDefaults.elevation(6.dp)
@@ -246,38 +240,36 @@ fun ShowcaseSample() {
                         modifier = Modifier
                             .align(Alignment.TopCenter)
                             .clip(CircleShape)
-                            .onGloballyPositioned { coordinates ->
-                                targets["profile"] = IntroShowcaseTargets(
-                                    0, // specify index to show feature in order
-                                    coordinates, // specify coordinates of target
-                                    // ShowcaseStyle is optional
-                                    style = ShowcaseStyle.Default.copy(
-                                        backgroundColor = Color(0xFFFFCC80), // specify color of background
-                                        backgroundAlpha = 0.98f, // specify transparency of background
-                                        targetCircleColor = Color.White // specify color of target circle
-                                    ),
-                                    content = {
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(top = 20.dp)
-                                        ) {
-                                            Text(
-                                                text = "User profile",
-                                                color = Color.White,
-                                                fontSize = 24.sp,
-                                                fontWeight = FontWeight.Bold
-                                            )
-                                            Text(
-                                                text = "Click here to update your profile",
-                                                color = Color.White,
-                                                fontSize = 16.sp
-                                            )
-                                        }
+                            .introShowCaseTarget(
+                                state = introShowCaseState,
+                                index = 0, // specify index to show feature in order
+                                // ShowcaseStyle is optional
+                                style = ShowcaseStyle.Default.copy(
+                                    backgroundColor = Color(0xFFFFCC80), // specify color of background
+                                    backgroundAlpha = 0.98f, // specify transparency of background
+                                    targetCircleColor = Color.White // specify color of target circle
+                                ),
+                                content = {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(top = 20.dp)
+                                    ) {
+                                        Text(
+                                            text = "User profile",
+                                            color = Color.White,
+                                            fontSize = 24.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                        Text(
+                                            text = "Click here to update your profile",
+                                            color = Color.White,
+                                            fontSize = 16.sp
+                                        )
                                     }
-                                )
-                            }
+                                }
+                            )
                     )
                 }
 
@@ -286,27 +278,25 @@ fun ShowcaseSample() {
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .padding(start = 16.dp, bottom = 16.dp)
-                        .onGloballyPositioned { coordinates ->
-                            targets["follow"] = IntroShowcaseTargets(
-                                3, coordinates,
-                                content = {
-                                    Column {
-                                        Text(
-                                            text = "Follow me",
-                                            color = Color.White,
-                                            fontSize = 24.sp,
-                                            fontWeight = FontWeight.Bold
-                                        )
-                                        Text(
-                                            text = "Click here to follow",
-                                            color = Color.White,
-                                            fontSize = 16.sp
-                                        )
-                                    }
-
+                        .introShowCaseTarget(
+                            state = introShowCaseState,
+                            index = 3,
+                            content = {
+                                Column {
+                                    Text(
+                                        text = "Follow me",
+                                        color = Color.White,
+                                        fontSize = 24.sp,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                    Text(
+                                        text = "Click here to follow",
+                                        color = Color.White,
+                                        fontSize = 16.sp
+                                    )
                                 }
-                            )
-                        }
+                            }
+                        )
                 ) {
                     Text(text = "Follow")
                 }
@@ -315,7 +305,7 @@ fun ShowcaseSample() {
         }
 
         if (showAppIntro) {
-            IntroShowCase(targets) {
+            IntroShowCase(introShowCaseState) {
                 //App Intro finished!!
                 showAppIntro = false
             }

--- a/app/src/main/java/com/canopas/campose/showcase/MainActivity.kt
+++ b/app/src/main/java/com/canopas/campose/showcase/MainActivity.kt
@@ -46,10 +46,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.canopas.campose.showcase.ui.theme.JetTapTargetTheme
 import com.canopas.campose.showcase.ui.theme.ThemeColor
-import com.canopas.lib.showcase.IntroShowCase
+import com.canopas.lib.showcase.IntroShowCaseScaffold
 import com.canopas.lib.showcase.ShowcaseStyle
-import com.canopas.lib.showcase.introShowCaseTarget
-import com.canopas.lib.showcase.rememberIntroShowCaseState
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,13 +68,17 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun ShowcaseSample() {
-    val introShowCaseState = rememberIntroShowCaseState()
-
     var showAppIntro by remember {
         mutableStateOf(true)
     }
 
-    Box {
+    IntroShowCaseScaffold(
+        showIntroShowCase = showAppIntro,
+        onShowCaseCompleted = {
+            //App Intro finished!!
+            showAppIntro = false
+        },
+    ) {
         Scaffold(
             modifier = Modifier.fillMaxSize(),
             topBar = {
@@ -85,9 +87,9 @@ fun ShowcaseSample() {
                     backgroundColor = Color.Transparent,
                     elevation = 0.dp,
                     navigationIcon = {
-                        IconButton(onClick = {},
+                        IconButton(
+                            onClick = {},
                             modifier = Modifier.introShowCaseTarget(
-                                state = introShowCaseState,
                                 index = 4,
                                 style = ShowcaseStyle.Default.copy(
                                     backgroundColor = Color(0xFF7C99AC), // specify color of background
@@ -127,7 +129,6 @@ fun ShowcaseSample() {
                         IconButton(
                             onClick = {},
                             modifier = Modifier.introShowCaseTarget(
-                                state = introShowCaseState,
                                 index = 2,
                                 style = ShowcaseStyle.Default.copy(
                                     backgroundColor = Color(0xFF9AD0EC), // specify color of background
@@ -166,7 +167,6 @@ fun ShowcaseSample() {
                 FloatingActionButton(
                     onClick = {},
                     modifier = Modifier.introShowCaseTarget(
-                        state = introShowCaseState,
                         index = 1,
                         style = ShowcaseStyle.Default.copy(
                             backgroundColor = Color(0xFF1C0A00), // specify color of background
@@ -241,7 +241,6 @@ fun ShowcaseSample() {
                             .align(Alignment.TopCenter)
                             .clip(CircleShape)
                             .introShowCaseTarget(
-                                state = introShowCaseState,
                                 index = 0, // specify index to show feature in order
                                 // ShowcaseStyle is optional
                                 style = ShowcaseStyle.Default.copy(
@@ -279,7 +278,6 @@ fun ShowcaseSample() {
                         .align(Alignment.BottomStart)
                         .padding(start = 16.dp, bottom = 16.dp)
                         .introShowCaseTarget(
-                            state = introShowCaseState,
                             index = 3,
                             content = {
                                 Column {
@@ -300,14 +298,6 @@ fun ShowcaseSample() {
                 ) {
                     Text(text = "Follow")
                 }
-
-            }
-        }
-
-        if (showAppIntro) {
-            IntroShowCase(introShowCaseState) {
-                //App Intro finished!!
-                showAppIntro = false
             }
         }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,17 +26,20 @@ implementation 'com.canopas.intro-showcase-view:introshowcaseview:1.0.5'
 ```kotlin
 @Composable
 fun ShowcaseSample() {
-    val introShowCaseState = rememberIntroShowCaseState()
-
     var showAppIntro by remember {
         mutableStateOf(true)
     }
 
-    Box {
+    IntroShowCaseScaffold(
+        showIntroShowCase = showAppIntro,
+        onShowCaseCompleted = {
+            //App Intro finished!!
+            showAppIntro = false
+        },
+    ) {
         FloatingActionButton(
             onClick = {},
             modifier = Modifier.introShowCaseTarget(
-                state = introShowCaseState,
                 index = 0,
                 style = ShowcaseStyle.Default.copy(
                     backgroundColor = Color(0xFF1C0A00), // specify color of background
@@ -77,13 +80,6 @@ fun ShowcaseSample() {
                 Icons.Filled.Email,
                 contentDescription = "Email"
             )
-        }
-
-        if (showAppIntro) {
-            IntroShowCase(introShowCaseState) {
-                //App Intro finished!!
-                showAppIntro = false
-            }
         }
     }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,79 +19,74 @@ Available on [Maven Central](https://search.maven.org/artifact/com.canopas.intro
 
 Add the dependency
 ```gradle
-    implementation 'com.canopas.intro-showcase-view:introshowcaseview:1.0.5'
-
+implementation 'com.canopas.intro-showcase-view:introshowcaseview:1.0.5'
 ```
 
 ## How to use ?
 ```kotlin
 @Composable
 fun ShowcaseSample() {
-  val targets = remember {
-          mutableStateMapOf<String, IntroShowcaseTargets>()
-      }
-      var showAppIntro by remember {
-          mutableStateOf(true)
-      }
+    val introShowCaseState = rememberIntroShowCaseState()
 
-      Box {
-          FloatingActionButton(
-              onClick = {},
-              modifier = Modifier.onGloballyPositioned { coordinates ->
-                  targets["email"] = IntroShowcaseTargets(
-                      1, coordinates,
-                      style = ShowcaseStyle.Default.copy(
-                          backgroundColor = Color(0xFF1C0A00), // specify color of background
-                          backgroundAlpha = 0.98f, // specify transparency of background
-                          targetCircleColor = Color.White // specify color of target circle
-                      ),
-                      // specify the content to show to introduce app feature
-                      content = {
-                          Column {
-                              Text(
-                                  text = "Check emails",
-                                  color = Color.White,
-                                  fontSize = 24.sp,
-                                  fontWeight = FontWeight.Bold
-                              )
-                              Text(
-                                  text = "Click here to check/send emails",
-                                  color = Color.White,
-                                  fontSize = 16.sp
-                              )
-                              Spacer(modifier = Modifier.height(10.dp))
-                              Icon(
-                                  painterResource(id = R.drawable.right_arrow),
-                                  contentDescription = null,
-                                  modifier = Modifier
-                                      .size(80.dp)
-                                      .align(Alignment.End),
-                                  tint = Color.White
-                              )
-                          }
+    var showAppIntro by remember {
+        mutableStateOf(true)
+    }
 
-                      }
-                  )
-              },
-              backgroundColor = ThemeColor,
-              contentColor = Color.White,
-              elevation = FloatingActionButtonDefaults.elevation(6.dp)
-          ) {
-              Icon(
-                  Icons.Filled.Email,
-                  contentDescription = "Email"
-              )
-          }
+    Box {
+        FloatingActionButton(
+            onClick = {},
+            modifier = Modifier.introShowCaseTarget(
+                state = introShowCaseState,
+                index = 0,
+                style = ShowcaseStyle.Default.copy(
+                    backgroundColor = Color(0xFF1C0A00), // specify color of background
+                    backgroundAlpha = 0.98f, // specify transparency of background
+                    targetCircleColor = Color.White // specify color of target circle
+                ),
+                // specify the content to show to introduce app feature
+                content = {
+                    Column {
+                        Text(
+                            text = "Check emails",
+                            color = Color.White,
+                            fontSize = 24.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = "Click here to check/send emails",
+                            color = Color.White,
+                            fontSize = 16.sp
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Icon(
+                            painterResource(id = R.drawable.right_arrow),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(80.dp)
+                                .align(Alignment.End),
+                            tint = Color.White
+                        )
+                    }
+                }
+            ),
+            backgroundColor = ThemeColor,
+            contentColor = Color.White,
+            elevation = FloatingActionButtonDefaults.elevation(6.dp)
+        ) {
+            Icon(
+                Icons.Filled.Email,
+                contentDescription = "Email"
+            )
+        }
 
-          if (showAppIntro) {
-              IntroShowCase(targets) {
-                  //App Intro finished!!
-                  showAppIntro = false
-              }
-          }
-      }
+        if (showAppIntro) {
+            IntroShowCase(introShowCaseState) {
+                //App Intro finished!!
+                showAppIntro = false
+            }
+        }
+    }
 }
-
 ```
 <img src="assets/intro2.gif" height="480" />
 <img src="assets/intro3.gif" height="480" />

--- a/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -52,27 +51,6 @@ fun IntroShowCase(
         TargetContent(it) {
             state.currentTargetIndex++
             if (state.currentTarget == null) {
-                onShowcaseCompleted()
-            }
-        }
-    }
-}
-
-@Composable
-fun IntroShowCase(
-    targets: SnapshotStateMap<String, IntroShowcaseTargets>,
-    onShowcaseCompleted: () -> Unit
-) {
-    val uniqueTargets = targets.values.sortedBy { it.index }
-    var currentTargetIndex by remember { mutableStateOf(0) }
-
-    val currentTarget =
-        if (uniqueTargets.isNotEmpty() && currentTargetIndex < uniqueTargets.size) uniqueTargets[currentTargetIndex] else null
-
-
-    currentTarget?.let {
-        TargetContent(it) {
-            if (++currentTargetIndex >= uniqueTargets.size) {
                 onShowcaseCompleted()
             }
         }

--- a/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
@@ -36,12 +36,27 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
-import kotlinx.coroutines.delay
+
+@Composable
+fun IntroShowCase(
+    state: IntroShowCaseState,
+    onShowcaseCompleted: () -> Unit
+) {
+    state.currentTarget?.let {
+        TargetContent(it) {
+            state.currentTargetIndex++
+            if (state.currentTarget == null) {
+                onShowcaseCompleted()
+            }
+        }
+    }
+}
 
 @Composable
 fun IntroShowCase(

--- a/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCase.kt
@@ -45,13 +45,13 @@ import kotlin.math.sqrt
 @Composable
 fun IntroShowCase(
     state: IntroShowCaseState,
-    onShowcaseCompleted: () -> Unit
+    onShowCaseCompleted: () -> Unit
 ) {
     state.currentTarget?.let {
         TargetContent(it) {
             state.currentTargetIndex++
             if (state.currentTarget == null) {
-                onShowcaseCompleted()
+                onShowCaseCompleted()
             }
         }
     }

--- a/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCaseScaffold.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCaseScaffold.kt
@@ -1,0 +1,51 @@
+package com.canopas.lib.showcase
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+@Composable
+fun IntroShowCaseScaffold(
+    showIntroShowCase: Boolean,
+    onShowCaseCompleted: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: IntroShowCaseState = rememberIntroShowCaseState(),
+    content: @Composable IntroShowCaseScope.() -> Unit,
+) {
+    val scope = remember(state) {
+        IntroShowCaseScope(state)
+    }
+
+    Box(modifier) {
+
+        scope.content()
+
+        if (showIntroShowCase) {
+            IntroShowCase(
+                state = state,
+                onShowCaseCompleted = onShowCaseCompleted,
+            )
+        }
+    }
+}
+
+class IntroShowCaseScope(
+    private val state: IntroShowCaseState,
+) {
+
+    /**
+     * Modifier that marks Compose UI element as a target for [IntroShowCase]
+     */
+    fun Modifier.introShowCaseTarget(
+        index: Int,
+        style: ShowcaseStyle = ShowcaseStyle.Default,
+        content: @Composable BoxScope.() -> Unit,
+    ): Modifier = introShowCaseTarget(
+        state = state,
+        index = index,
+        style = style,
+        content = content,
+    )
+}

--- a/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCaseState.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/IntroShowCaseState.kt
@@ -1,0 +1,61 @@
+package com.canopas.lib.showcase
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+
+/**
+ * Creates a [IntroShowCaseState] that is remembered across compositions.
+ *
+ * Changes to the provided values for [initialIndex] will **not** result in the state being
+ * recreated or changed in any way if it has already
+ * been created.
+ *
+ * @param initialIndex the initial value for [IntroShowCaseState.currentTargetIndex]
+ */
+@Composable
+fun rememberIntroShowCaseState(
+    initialIndex: Int = 0,
+): IntroShowCaseState {
+    return remember {
+        IntroShowCaseState(
+            initialIndex = initialIndex,
+        )
+    }
+}
+
+/**
+ * Modifier that marks Compose UI element as a target for [IntroShowCase]
+ */
+fun Modifier.introShowCaseTarget(
+    state: IntroShowCaseState,
+    index: Int,
+    style: ShowcaseStyle = ShowcaseStyle.Default,
+    content: @Composable BoxScope.() -> Unit,
+): Modifier = onGloballyPositioned { coordinates ->
+    state.targets[index] = IntroShowcaseTargets(
+        index = index,
+        coordinates = coordinates,
+        style = style,
+        content = content
+    )
+}
+
+class IntroShowCaseState internal constructor(
+    initialIndex: Int,
+) {
+
+    internal var targets = mutableStateMapOf<Int, IntroShowcaseTargets>()
+
+    var currentTargetIndex by mutableStateOf(initialIndex)
+        internal set
+
+    val currentTarget: IntroShowcaseTargets?
+        get() = targets[currentTargetIndex]
+}


### PR DESCRIPTION
Hi, nice work with this library! I've been playing around with it and I found some place for potential improvement, feel free to go through it and tell me what you think.

It felt a bit rough how user has to keep targets map and add targets to it itself and also how `onGloballyPositioned` modifier has to be used directly. So I created `IntroShowCaseState`, pretty much how core compose ui components do it, which holds the targets map, and `introShowCaseTarget` modifier which wraps `onGloballyPositioned` so that user doesn't have to know about `LayoutCoordinates` and the low level implementation.

I also created `IntroShowCaseScaffold` which can optionally be used instead of wrapping the content and `IntroShowCase` in a `Box`, can handle `IntroShowCaseState` creation in most cases, and introduces `IntroShowCaseScope` with simplified version of `introShowCaseTarget` modifier.