### PR TITLE
Fix layout coordinates crash when composable is not attached

### DIFF
--- a/showcase/src/main/java/com/canopas/lib/showcase/component/ShowcaseContent.kt
+++ b/showcase/src/main/java/com/canopas/lib/showcase/component/ShowcaseContent.kt
@@ -51,14 +51,16 @@ fun ShowcasePopup(
     onShowCaseCompleted: () -> Unit,
 ) {
     state.currentTarget?.let {
-        ShowcaseWindow {
-            ShowcaseContent(
-                target = it,
-                dismissOnClickOutside = dismissOnClickOutside
-            ) {
-                state.currentTargetIndex++
-                if (state.currentTarget == null) {
-                    onShowCaseCompleted()
+        if (it.coordinates.isAttached) {
+            ShowcaseWindow {
+                ShowcaseContent(
+                    target = it,
+                    dismissOnClickOutside = dismissOnClickOutside
+                ) {
+                    state.currentTargetIndex++
+                    if (state.currentTarget == null) {
+                        onShowCaseCompleted()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## BugFix

- Fixed a crash related to layout coordinates being accessed when not attached([issue](https://github.com/canopas/compose-intro-showcase/issues/23))

